### PR TITLE
Update manifest.json to require jsonpath package (#21)

### DIFF
--- a/custom_components/krisinformation/manifest.json
+++ b/custom_components/krisinformation/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/isabellaalstrom/sensor.krisinformation",
   "dependencies": [],
   "codeowners": ["@isabellaalstrom"],
-  "requirements": []
+  "requirements": ["jsonpath>=0.82"]
 }


### PR DESCRIPTION
It looks like the jsonpath package is no longer required by HA core as of version 0.106.  I propose adding the current version as a minimum.